### PR TITLE
Write discrepancies into SQL table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ configuration file defines the source and destination schemas and tables,
 column mappings and a simple partitioning scheme. The included Python scripts
 load this configuration, connect to both databases, fetch rows for each
 partition and compare them column by column. Any discrepancies are
-written to a CSV report.
+written to a table on the destination SQL Server.
 
 ## Structure
 
@@ -30,7 +30,7 @@ written to a CSV report.
    ```bash
    python scripts/reconcile_runner.py
    ```
-   Discrepancies will be written to the path specified in the config
+   Discrepancies will be written to the table specified in the config
    file.
 
 This repository is intentionally minimal and focuses only on the core

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -37,5 +37,6 @@ partitioning:
     - { year: 2021, month: 2 }
 
 output:
-  format: csv
-  path: "output/discrepancies.csv"
+  format: table
+  schema: recon
+  table: discrepancies

--- a/logic/reporter.py
+++ b/logic/reporter.py
@@ -2,6 +2,7 @@
 
 import csv
 import os
+import pyodbc
 
 
 def write_discrepancies_to_csv(discrepancies: list[dict], output_path: str):
@@ -22,3 +23,43 @@ def write_discrepancies_to_csv(discrepancies: list[dict], output_path: str):
         writer.writerows(discrepancies)
 
     print(f"Discrepancy report written to: {output_path}")
+
+
+def write_discrepancies_to_table(
+    discrepancies: list[dict],
+    conn: pyodbc.Connection,
+    schema: str,
+    table: str,
+):
+    """Write discrepancy records to a table in SQL Server."""
+
+    if not discrepancies:
+        print("No discrepancies found.")
+        return
+
+    cursor = conn.cursor()
+
+    full_table = f"{schema}.{table}" if schema else table
+
+    # Drop table if it already exists
+    drop_sql = f"IF OBJECT_ID('{full_table}', 'U') IS NOT NULL DROP TABLE {full_table}" 
+    cursor.execute(drop_sql)
+
+    columns = list(discrepancies[0].keys())
+    column_defs = ", ".join(f"[{c}] NVARCHAR(MAX)" for c in columns)
+    create_sql = f"CREATE TABLE {full_table} ({column_defs})"
+    cursor.execute(create_sql)
+
+    placeholders = ", ".join("?" for _ in columns)
+    insert_sql = (
+        f"INSERT INTO {full_table} ({', '.join('[' + c + ']' for c in columns)}) "
+        f"VALUES ({placeholders})"
+    )
+
+    for record in discrepancies:
+        values = [record.get(c) for c in columns]
+        cursor.execute(insert_sql, values)
+
+    conn.commit()
+
+    print(f"Discrepancy report written to table: {full_table}")

--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -6,7 +6,7 @@ from connectors.sqlserver_connector import get_sqlserver_connection
 from logic.partitioner import get_partitions
 from runners.reconcile import fetch_rows
 from logic.comparator import compare_rows
-from logic.reporter import write_discrepancies_to_csv
+from logic.reporter import write_discrepancies_to_table
 
 
 def main():
@@ -21,7 +21,8 @@ def main():
     src_cols = config["source"]["columns"]
     dest_cols = config["destination"]["columns"]
     primary_key = config["primary_key"]
-    output_path = config["output"]["path"]
+    output_schema = config["output"].get("schema", "")
+    output_table = config["output"]["table"]
 
     all_discrepancies = []
 
@@ -71,7 +72,7 @@ def main():
                     "month": partition["month"]
                 })
 
-    write_discrepancies_to_csv(all_discrepancies, output_path)
+    write_discrepancies_to_table(all_discrepancies, dest_conn, output_schema, output_table)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- output discrepancies to a SQL Server table instead of CSV
- add a helper for creating the table and inserting the rows
- update example config and runner to use the new function
- revise README to note the updated behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b809816c4832c96a43bf077d714a6