### PR TITLE
Ensure case-insensitive column handling

### DIFF
--- a/logic/comparator.py
+++ b/logic/comparator.py
@@ -14,13 +14,13 @@ def compare_rows(source_row: dict, dest_row: dict, column_map: dict) -> list[dic
         }
     """
     mismatches = []
-    for logical_col, _ in column_map.items():
-        src_val = source_row.get(column_map[logical_col])
-        dest_val = dest_row.get(column_map[logical_col])
+    for logical_col in column_map.keys():
+        src_val = source_row.get(logical_col)
+        dest_val = dest_row.get(logical_col)
         if src_val != dest_val:
             mismatches.append({
                 "column": logical_col,
                 "source_value": src_val,
-                "dest_value": dest_val
+                "dest_value": dest_val,
             })
     return mismatches

--- a/logic/config_loader.py
+++ b/logic/config_loader.py
@@ -52,4 +52,10 @@ def load_config(path: str = "config/config.yaml") -> dict:
             k: v for k, v in dest_cols.items() if k in src_cols
         }
 
+    def _lower_map(col_map: dict) -> dict:
+        return {k.lower(): v.lower() for k, v in col_map.items()}
+
+    raw_config["source"]["columns"] = _lower_map(raw_config["source"]["columns"])
+    raw_config["destination"]["columns"] = _lower_map(raw_config["destination"]["columns"])
+
     return raw_config

--- a/runners/reconcile.py
+++ b/runners/reconcile.py
@@ -16,8 +16,9 @@ def fetch_rows(
     year = partition["year"]
     month = partition["month"]
 
-    col_list = [f"{v}" for v in columns.values()]
-    select_clause = ", ".join(col_list)
+    logical_cols = list(columns.keys())
+    physical_cols = [columns[c] for c in logical_cols]
+    select_clause = ", ".join(physical_cols)
 
     full_table = f"{schema}.{table}" if schema else table
 
@@ -37,4 +38,4 @@ def fetch_rows(
         if not rows:
             break
         for row in rows:
-            yield dict(zip(col_list, row))
+            yield dict(zip(logical_cols, row))

--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -36,8 +36,8 @@ def main():
             dest_row = next(dest_iter, None)
 
             while src_row is not None or dest_row is not None:
-                src_key = src_row[src_cols[primary_key]] if src_row else None
-                dest_key = dest_row[dest_cols[primary_key]] if dest_row else None
+                src_key = src_row[primary_key] if src_row else None
+                dest_key = dest_row[primary_key] if dest_row else None
 
                 if src_row and dest_row and src_key == dest_key:
                     diffs = compare_rows(src_row, dest_row, src_cols)


### PR DESCRIPTION
## Summary
- normalize column names to lowercase when loading config
- return logical column names when fetching rows
- update compare logic to use logical column names
- adjust reconciliation runner to new row format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b8aef40b8832c8e6ca625e3aa5d60