### PR TITLE
Add weekly partitioning support

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -32,8 +32,11 @@ primary_key: id
 partitioning:
   year_column: year
   month_column: month
+  week_column: week
   scope:
-    - { year: '2021', month: '01' }
+    - { year: '2024', month: '05', weeks: [1, 2, 3, 4] }
+    - { year: '2024', month: '06', weeks: [1, 2, 3, 4, 5] }
+    - { year: '2023', month: '12' }  # fallback to month-only
 
 output:
   format: table

--- a/logic/partitioner.py
+++ b/logic/partitioner.py
@@ -4,8 +4,25 @@ from typing import Dict, Iterable
 
 
 def get_partitions(config: Dict) -> Iterable[Dict]:
-    """Yield partition dictionaries from the loaded configuration."""
-    part_cfg = config.get("partitioning", {})
-    scope = part_cfg.get("scope", [])
-    for part in scope:
-        yield part
+    """Yield partition dictionaries expanded from the config's partitioning scope.
+    Supports optional weekly partitioning using 'weeks' lists.
+    Falls back to month-only partitions if no weeks are specified."""
+
+    scope = config.get("partitioning", {}).get("scope", [])
+
+    for entry in scope:
+        year = str(entry["year"])
+        month = str(entry["month"]).zfill(2)
+
+        if "weeks" in entry:
+            for week in entry["weeks"]:
+                yield {
+                    "year": year,
+                    "month": month,
+                    "week": str(week)
+                }
+        else:
+            yield {
+                "year": year,
+                "month": month
+            }

--- a/tests/test_fetch_rows.py
+++ b/tests/test_fetch_rows.py
@@ -24,5 +24,5 @@ def test_fetch_rows_casts_partition_to_str():
     conn = DummyConn()
     columns = {"id": "id", "year": "yr", "month": "mon"}
     partition = {"year": 2021, "month": 1}
-    list(fetch_rows(conn, "dbo", "t", columns, partition, "id"))
+    list(fetch_rows(conn, "dbo", "t", columns, partition, "id", "yr", "mon"))
     assert conn.cursor_obj.executed == ("2021", "1")

--- a/tests/test_partitioner.py
+++ b/tests/test_partitioner.py
@@ -2,7 +2,7 @@ import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(
 from logic.partitioner import get_partitions
 
 
-def test_get_partitions():
+def test_get_partitions_month_only():
     config = {
         "partitioning": {
             "scope": [
@@ -13,4 +13,23 @@ def test_get_partitions():
     }
 
     parts = list(get_partitions(config))
-    assert parts == [{"year": 2021, "month": 1}, {"year": 2021, "month": 2}]
+    assert parts == [
+        {"year": "2021", "month": "01"},
+        {"year": "2021", "month": "02"},
+    ]
+
+
+def test_get_partitions_with_weeks():
+    config = {
+        "partitioning": {
+            "scope": [
+                {"year": 2022, "month": 5, "weeks": [1, 2]},
+            ]
+        }
+    }
+
+    parts = list(get_partitions(config))
+    assert parts == [
+        {"year": "2022", "month": "05", "week": "1"},
+        {"year": "2022", "month": "05", "week": "2"},
+    ]


### PR DESCRIPTION
## Summary
- allow weekly filtering in `config.yaml`
- expand weekly entries in `get_partitions`
- update partitioner and fetch_rows tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4ee18874832cb03a649d33a9254e