### PR TITLE
Enable optional weekly partition filter

### DIFF
--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -26,6 +26,7 @@ def main():
 
     year_column = config["partitioning"]["year_column"]
     month_column = config["partitioning"]["month_column"]
+    week_column = config["partitioning"].get("week_column")
 
     src_dialect = config["source"].get("type", "sqlserver").lower()
     dest_dialect = config["destination"].get("type", "sqlserver").lower()
@@ -38,11 +39,13 @@ def main():
 
             src_rows = list(fetch_rows(
                 src_conn, src_schema, src_table, src_cols, partition,
-                primary_key, year_column, month_column, dialect=src_dialect
+                primary_key, year_column, month_column, dialect=src_dialect,
+                week_column=week_column
             ))
             dest_rows = list(fetch_rows(
                 dest_conn, dest_schema, dest_table, dest_cols, partition,
-                primary_key, year_column, month_column, dialect=dest_dialect
+                primary_key, year_column, month_column, dialect=dest_dialect,
+                week_column=week_column
             ))
 
             src_iter = iter(src_rows)

--- a/tests/test_fetch_rows.py
+++ b/tests/test_fetch_rows.py
@@ -26,3 +26,45 @@ def test_fetch_rows_casts_partition_to_str():
     partition = {"year": 2021, "month": 1}
     list(fetch_rows(conn, "dbo", "t", columns, partition, "id", "yr", "mon"))
     assert conn.cursor_obj.executed == ("2021", "1")
+
+
+def test_fetch_rows_filters_week_sqlserver():
+    conn = DummyConn()
+    columns = {"id": "id", "year": "yr", "month": "mon", "week": "wk"}
+    partition = {"year": 2021, "month": 1, "week": 2}
+    list(
+        fetch_rows(
+            conn,
+            "dbo",
+            "t",
+            columns,
+            partition,
+            "id",
+            "yr",
+            "mon",
+            dialect="sqlserver",
+            week_column="wk",
+        )
+    )
+    assert conn.cursor_obj.executed == ("2021", "1", "2")
+
+
+def test_fetch_rows_filters_week_oracle():
+    conn = DummyConn()
+    columns = {"id": "id", "year": "yr", "month": "mon", "week": "wk"}
+    partition = {"year": 2021, "month": 1, "week": 3}
+    list(
+        fetch_rows(
+            conn,
+            "dbo",
+            "t",
+            columns,
+            partition,
+            "id",
+            "yr",
+            "mon",
+            dialect="oracle",
+            week_column="wk",
+        )
+    )
+    assert conn.cursor_obj.executed == ("2021", "1", "3")


### PR DESCRIPTION
## Summary
- allow `fetch_rows()` to accept a `week_column`
- include week parameter in SQL when supplied
- pass week column from runner
- expand tests to cover weekly filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c50ee5118832cbd4c2a4f59d76eaa