### PR TITLE
Handle float and date equality in comparator

### DIFF
--- a/logic/comparator.py
+++ b/logic/comparator.py
@@ -1,5 +1,35 @@
 """Functions for comparing row dictionaries between databases."""
 
+from __future__ import annotations
+
+from typing import Any
+
+from dateutil import parser
+
+
+def values_equal(source_val: Any, dest_val: Any) -> bool:
+    """Return ``True`` if the two provided values should be considered equal."""
+    # Attempt numeric comparison with tolerance
+    try:
+        a = float(source_val)
+        b = float(dest_val)
+        if abs(a - b) < 1e-5:
+            return True
+    except Exception:
+        pass
+
+    # Attempt date comparison ignoring time component
+    try:
+        d1 = parser.parse(str(source_val)).date()
+        d2 = parser.parse(str(dest_val)).date()
+        if d1 == d2:
+            return True
+    except Exception:
+        pass
+
+    # Fallback to string equality
+    return str(source_val) == str(dest_val)
+
 
 def compare_rows(source_row: dict, dest_row: dict, column_map: dict) -> list[dict]:
     """
@@ -17,7 +47,7 @@ def compare_rows(source_row: dict, dest_row: dict, column_map: dict) -> list[dic
     for logical_col in column_map.keys():
         src_val = source_row.get(logical_col)
         dest_val = dest_row.get(logical_col)
-        if src_val != dest_val:
+        if not values_equal(src_val, dest_val):
             mismatches.append({
                 "column": logical_col,
                 "source_value": src_val,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+
+python-dateutil

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -1,5 +1,6 @@
 import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from logic.comparator import compare_rows
+from decimal import Decimal
 
 
 def test_compare_rows():
@@ -8,3 +9,19 @@ def test_compare_rows():
     columns = {"id": "id", "col": "col"}
     diffs = compare_rows(src, dest, columns)
     assert diffs == [{"column": "col", "source_value": "a", "dest_value": "b"}]
+
+
+def test_compare_rows_numeric_tolerance():
+    src = {"id": 1, "amount": Decimal("-265.23")}
+    dest = {"id": 1, "amount": -265.230000}
+    columns = {"id": "id", "amount": "amount"}
+    diffs = compare_rows(src, dest, columns)
+    assert diffs == []
+
+
+def test_compare_rows_date_equality():
+    src = {"id": 1, "date": "2020-10-04 00:00:00.0000000"}
+    dest = {"id": 1, "date": "2020-10-04"}
+    columns = {"id": "id", "date": "date"}
+    diffs = compare_rows(src, dest, columns)
+    assert diffs == []


### PR DESCRIPTION
## Summary
- add flexible `values_equal` helper
- update comparison to use tolerance for numbers and ignore time when comparing dates
- cover new logic with tests
- declare python-dateutil requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5807f2e8832ca91ae327772eb09b