### PR TITLE
Add row-level hash comparison optimization

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,6 +29,9 @@ destination:
 
 primary_key: id
 
+comparison:
+  use_row_hash: true
+
 partitioning:
   year_column: year
   month_column: month

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -1,5 +1,5 @@
 import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from logic.comparator import compare_rows
+from logic.comparator import compare_rows, compute_row_hash
 from decimal import Decimal
 
 
@@ -25,3 +25,29 @@ def test_compare_rows_date_equality():
     columns = {"id": "id", "date": "date"}
     diffs = compare_rows(src, dest, columns)
     assert diffs == []
+
+
+def test_compute_row_hash_and_skip():
+    src = {"id": 1, "col": "a"}
+    dest = {"id": 1, "col": "a"}
+    columns = {"id": "id", "col": "col"}
+    diffs = compare_rows(src, dest, columns, use_row_hash=True)
+    assert diffs == []
+
+
+def test_compare_rows_row_hash_mismatch():
+    src = {"id": 1, "col": "a"}
+    dest = {"id": 1, "col": "b"}
+    columns = {"id": "id", "col": "col"}
+    expected_src_hash = compute_row_hash(src)
+    expected_dest_hash = compute_row_hash(dest)
+    diffs = compare_rows(src, dest, columns, use_row_hash=True)
+    assert diffs == [
+        {
+            "column": "col",
+            "source_value": "a",
+            "dest_value": "b",
+            "source_hash": expected_src_hash,
+            "dest_hash": expected_dest_hash,
+        }
+    ]


### PR DESCRIPTION
## Summary
- include optional `comparison.use_row_hash` in the sample config
- implement `compute_row_hash` and hash-based short-circuiting in `compare_rows`
- pass row hashes through the reconcile runner when enabled
- extend comparator tests for new behaviour

## Testing
- `pip install -q python-dateutil`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6e7f2378832c9693caec9d5ef5b0