### PR TITLE
Add debug logging mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ written to a table on the destination SQL Server.
    Discrepancies will be written to the table specified in the config
    file.
 
+Passing the `--debug` flag or setting `debug: true` in the YAML
+configuration enables verbose logging useful during development.
+
 This repository is intentionally minimal and focuses only on the core
 logic for comparing tables. Many features are missing, including retry
 logic, logging and tests.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,5 @@
 # Example configuration for reconciling Oracle to SQL Server tables
+debug: true
 source:
   type: oracle
   env:

--- a/connectors/oracle_connector.py
+++ b/connectors/oracle_connector.py
@@ -1,12 +1,16 @@
 """Utility for creating Oracle database connections using oracledb."""
 
+from typing import Optional
+
+from utils.logger import debug_log
+
 try:
     import oracledb
 except ImportError:
     raise ImportError("Please install 'oracledb' via pip: pip install oracledb")
 
 
-def get_oracle_connection(env: dict):
+def get_oracle_connection(env: dict, config: Optional[dict] = None):
     """
     Return an Oracle connection using resolved environment settings.
     Requires: user, password, host, port, service
@@ -18,4 +22,5 @@ def get_oracle_connection(env: dict):
     service = env["service"]
 
     dsn = oracledb.makedsn(host, port, service_name=service)
+    debug_log(f"Connecting to Oracle with DSN: {dsn}", config)
     return oracledb.connect(user=user, password=password, dsn=dsn)

--- a/connectors/sqlserver_connector.py
+++ b/connectors/sqlserver_connector.py
@@ -1,10 +1,14 @@
 
 """Helpers for connecting to Microsoft SQL Server."""
 
+from typing import Optional
+
+from utils.logger import debug_log
+
 import pyodbc
 
 
-def get_sqlserver_connection(env: dict):
+def get_sqlserver_connection(env: dict, config: Optional[dict] = None):
     """Create and return a :class:`pyodbc.Connection` using environment data."""
     driver = env["driver"]
     server = env["server"]
@@ -19,5 +23,6 @@ def get_sqlserver_connection(env: dict):
         f"Trusted_Connection={trusted};"
         f"TrustServerCertificate={trust_cert};"
     )
+    debug_log(f"Connecting to SQL Server with: {server}/{database}", config)
 
     return pyodbc.connect(conn_str)

--- a/logic/config_loader.py
+++ b/logic/config_loader.py
@@ -4,6 +4,8 @@ import yaml
 import os
 from dotenv import load_dotenv
 
+from utils.logger import debug_log
+
 load_dotenv()
 
 
@@ -15,9 +17,9 @@ def get_env_var(name: str) -> str:
     return value
 
 
-def resolve_env_vars(env_map: dict) -> dict:
+def resolve_env_vars(env_map: dict, debug: bool = False) -> dict:
     """Expand a mapping of variable names to actual environment values."""
-    print("Resolving environment variables for:", env_map)
+    debug_log(f"Resolving environment variables for: {env_map}", {"debug": debug})
     return {k: get_env_var(v) for k, v in env_map.items()}
 
 
@@ -26,12 +28,15 @@ def load_config(path: str = "config/config.yaml") -> dict:
     with open(path, "r") as f:
         raw_config = yaml.safe_load(f)
 
+    debug = raw_config.get("debug", False)
+    raw_config["debug"] = debug
+
     # Resolve and store separately for clarity
     source_env = raw_config["source"].get("env", {})
-    raw_config["source"]["resolved_env"] = resolve_env_vars(source_env)
+    raw_config["source"]["resolved_env"] = resolve_env_vars(source_env, debug)
 
     dest_env = raw_config["destination"].get("env", {})
-    raw_config["destination"]["resolved_env"] = resolve_env_vars(dest_env)
+    raw_config["destination"]["resolved_env"] = resolve_env_vars(dest_env, debug)
 
     # Normalize column definitions
     src_cols = raw_config["source"].get("columns", {})

--- a/runners/reconcile.py
+++ b/runners/reconcile.py
@@ -2,6 +2,8 @@
 
 from typing import Dict, Iterable, Optional
 
+from utils.logger import debug_log
+
 
 def fetch_rows(
     conn,
@@ -15,6 +17,7 @@ def fetch_rows(
     batch_size: int = 1000,
     dialect: str = "sqlserver",  # default to sqlserver
     week_column: Optional[str] = None,
+    config: Optional[dict] = None,
 ) -> Iterable[Dict]:
     """Yield rows filtered by partition in primary key order."""
     # Cast partition identifiers to strings so that filtering works for
@@ -56,7 +59,7 @@ def fetch_rows(
     else:
         raise ValueError(f"Unsupported SQL dialect: {dialect}")
 
-    print(f"Executing query: {query.strip()} | Params: {params}")
+    debug_log(f"Executing query: {query.strip()} | Params: {params}", config)
     read_cursor = conn.cursor()
     read_cursor.execute(query, params)
     read_cursor.arraysize = batch_size

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+def debug_log(message: str, config: dict | None = None) -> None:
+    """Print *message* prefixed with [DEBUG] when ``config['debug']`` is True."""
+    if config and config.get("debug", False):
+        print("[DEBUG]", message)


### PR DESCRIPTION
## Summary
- add `debug` flag to `config.yaml`
- implement `debug_log` helper and utilities module
- add optional debug logging to connectors, comparator, runner, and config loader
- expose `--debug` CLI flag in `reconcile_runner.py`
- document debug usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c77beeb6c832c94dc46c14086369e