### PR TITLE
Add debug level support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ written to a table on the destination SQL Server.
    Discrepancies will be written to the table specified in the config
    file.
 
-Passing the `--debug` flag or setting `debug: true` in the YAML
-configuration enables verbose logging useful during development.
+Passing the `--debug` flag or setting a debug level in the YAML
+configuration enables logging output. Supported levels are `low`,
+`medium` and `high`, where `high` produces the most verbose output.
 
 This repository is intentionally minimal and focuses only on the core
 logic for comparing tables. Many features are missing, including retry

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,5 @@
 # Example configuration for reconciling Oracle to SQL Server tables
-debug: true
+debug: high
 source:
   type: oracle
   env:

--- a/connectors/oracle_connector.py
+++ b/connectors/oracle_connector.py
@@ -22,5 +22,5 @@ def get_oracle_connection(env: dict, config: Optional[dict] = None):
     service = env["service"]
 
     dsn = oracledb.makedsn(host, port, service_name=service)
-    debug_log(f"Connecting to Oracle with DSN: {dsn}", config)
+    debug_log(f"Connecting to Oracle with DSN: {dsn}", config, level="low")
     return oracledb.connect(user=user, password=password, dsn=dsn)

--- a/connectors/sqlserver_connector.py
+++ b/connectors/sqlserver_connector.py
@@ -23,6 +23,10 @@ def get_sqlserver_connection(env: dict, config: Optional[dict] = None):
         f"Trusted_Connection={trusted};"
         f"TrustServerCertificate={trust_cert};"
     )
-    debug_log(f"Connecting to SQL Server with: {server}/{database}", config)
+    debug_log(
+        f"Connecting to SQL Server with: {server}/{database}",
+        config,
+        level="low",
+    )
 
     return pyodbc.connect(conn_str)

--- a/logic/comparator.py
+++ b/logic/comparator.py
@@ -70,15 +70,27 @@ def compare_rows(
     """
     mismatches = []
     pk_field = next(iter(column_map.keys()))
-    debug_log(f"Comparing source row {source_row.get(pk_field)}", config)
+    debug_log(
+        f"Comparing source row {source_row.get(pk_field)}",
+        config,
+        level="high",
+    )
     src_hash = dest_hash = None
 
     if use_row_hash:
         src_hash = compute_row_hash(source_row)
         dest_hash = compute_row_hash(dest_row)
-        debug_log(f"Source hash: {src_hash}, Dest hash: {dest_hash}", config)
+        debug_log(
+            f"Source hash: {src_hash}, Dest hash: {dest_hash}",
+            config,
+            level="high",
+        )
         if src_hash == dest_hash:
-            debug_log(f"Skipping row {source_row.get(pk_field)} - hashes match", config)
+            debug_log(
+                f"Skipping row {source_row.get(pk_field)} - hashes match",
+                config,
+                level="high",
+            )
             return mismatches
     for logical_col in column_map.keys():
         src_val = source_row.get(logical_col)
@@ -87,6 +99,7 @@ def compare_rows(
             debug_log(
                 f"MISMATCH: col={logical_col}, src={src_val}, dest={dest_val}",
                 config,
+                level="high",
             )
             mismatch = {
                 "column": logical_col,

--- a/logic/config_loader.py
+++ b/logic/config_loader.py
@@ -17,9 +17,13 @@ def get_env_var(name: str) -> str:
     return value
 
 
-def resolve_env_vars(env_map: dict, debug: bool = False) -> dict:
+def resolve_env_vars(env_map: dict, debug: str | bool = "low") -> dict:
     """Expand a mapping of variable names to actual environment values."""
-    debug_log(f"Resolving environment variables for: {env_map}", {"debug": debug})
+    debug_log(
+        f"Resolving environment variables for: {env_map}",
+        {"debug": debug},
+        level="high",
+    )
     return {k: get_env_var(v) for k, v in env_map.items()}
 
 
@@ -28,7 +32,13 @@ def load_config(path: str = "config/config.yaml") -> dict:
     with open(path, "r") as f:
         raw_config = yaml.safe_load(f)
 
-    debug = raw_config.get("debug", False)
+    raw_debug = raw_config.get("debug", "low")
+    if isinstance(raw_debug, bool):
+        debug = "high" if raw_debug else "low"
+    else:
+        debug = str(raw_debug).lower()
+        if debug not in {"low", "medium", "high"}:
+            debug = "low"
     raw_config["debug"] = debug
 
     # Resolve and store separately for clarity

--- a/runners/reconcile.py
+++ b/runners/reconcile.py
@@ -59,7 +59,11 @@ def fetch_rows(
     else:
         raise ValueError(f"Unsupported SQL dialect: {dialect}")
 
-    debug_log(f"Executing query: {query.strip()} | Params: {params}", config)
+    debug_log(
+        f"Executing query: {query.strip()} | Params: {params}",
+        config,
+        level="medium",
+    )
     read_cursor = conn.cursor()
     read_cursor.execute(query, params)
     read_cursor.arraysize = batch_size

--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -14,12 +14,18 @@ from utils.logger import debug_log
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--debug", action="store_true", help="enable debug logs")
+    parser.add_argument(
+        "--debug",
+        nargs="?",
+        const="high",
+        choices=["low", "medium", "high"],
+        help="set debug level",
+    )
     args = parser.parse_args()
 
     config = load_config()
     if args.debug:
-        config["debug"] = True
+        config["debug"] = args.debug
 
     src_env = config["source"]["resolved_env"]
     dest_env = config["destination"]["resolved_env"]
@@ -45,7 +51,11 @@ def main():
         writer = DiscrepancyWriter(dest_conn, output_schema, output_table)
 
         for partition in get_partitions(config):
-            debug_log(f"Partition: {partition}", config)
+            debug_log(
+                f"Partition: {partition}",
+                config,
+                level="low",
+            )
 
             src_rows = list(
                 fetch_rows(
@@ -81,6 +91,7 @@ def main():
             debug_log(
                 f"Fetched {len(src_rows)} source rows and {len(dest_rows)} destination rows",
                 config,
+                level="medium",
             )
 
             src_iter = iter(src_rows)

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,7 +1,26 @@
 from __future__ import annotations
 
 
-def debug_log(message: str, config: dict | None = None) -> None:
-    """Print *message* prefixed with [DEBUG] when ``config['debug']`` is True."""
-    if config and config.get("debug", False):
+def _get_config_level(config: dict | None) -> str:
+    """Return the configured debug level from *config*."""
+    if not config:
+        return "low"
+
+    cfg_val = config.get("debug", False)
+    if isinstance(cfg_val, bool):
+        return "high" if cfg_val else "low"
+    try:
+        level = str(cfg_val).lower()
+    except Exception:
+        return "low"
+    if level in {"low", "medium", "high"}:
+        return level
+    return "low"
+
+
+def debug_log(message: str, config: dict | None = None, *, level: str = "high") -> None:
+    """Print debug *message* when the configured level is >= ``level``."""
+    current = _get_config_level(config)
+    ranks = {"low": 1, "medium": 2, "high": 3}
+    if ranks.get(current, 1) >= ranks.get(level, 3):
         print("[DEBUG]", message)


### PR DESCRIPTION
## Summary
- support `low`, `medium`, and `high` debug levels
- log connection info at low level
- log query execution at medium level
- keep row comparison logging at high level
- update example config and README
- allow passing debug level via `--debug`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ceb03b080832c9228b081f80b74c2