### PR TITLE
Add progress bars to comparison and update phases

### DIFF
--- a/logic/comparator.py
+++ b/logic/comparator.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 import hashlib
 from concurrent.futures import ProcessPoolExecutor
 
 from dateutil import parser
+from tqdm import tqdm
 
 from utils.logger import debug_log
 
@@ -130,3 +131,25 @@ def compare_rows(
             mismatches.append(mismatch)
 
     return mismatches
+
+
+def compare_row_pairs(
+    row_pairs: Iterable[tuple],
+    *,
+    parallel: bool = False,
+    workers: int = 4,
+) -> list[Optional[list[dict]]]:
+    """Compare a sequence of row pairs with a progress bar."""
+    if parallel:
+        with ProcessPoolExecutor(max_workers=workers) as pool:
+            return list(
+                tqdm(
+                    pool.map(compare_row_pair, row_pairs),
+                    total=len(row_pairs),
+                    desc="Comparing rows",
+                )
+            )
+    else:
+        return [
+            compare_row_pair(p) for p in tqdm(row_pairs, desc="Comparing rows")
+        ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 
 python-dateutil
+tqdm

--- a/scripts/fix_mismatches.py
+++ b/scripts/fix_mismatches.py
@@ -6,6 +6,8 @@ import argparse
 from collections import defaultdict
 from typing import Dict, Optional
 
+from tqdm import tqdm
+
 from logic.config_loader import load_config
 from connectors.sqlserver_connector import get_sqlserver_connection
 from utils.logger import debug_log
@@ -63,11 +65,12 @@ def fix_mismatches(
         debug_log(f"Fetching mismatches with: {sql} | {tuple(params)}", config, level="medium")
         cur.execute(sql, tuple(params))
 
+        rows = cur.fetchall()
         summary: Dict[str, Dict] = defaultdict(
             lambda: {"total": 0, "updates": 0, "nulls": 0, "columns": defaultdict(int)}
         )
 
-        for pk, col, src_val, yr, mon in cur.fetchall():
+        for pk, col, src_val, yr, mon in tqdm(rows, desc="Applying fixes"):
             part_key = f"{yr}-{str(mon).zfill(2)}"
             info = summary[part_key]
             info["total"] += 1

--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -1,14 +1,13 @@
 """Command line entry point for running table reconciliation."""
 
 import argparse
-from concurrent.futures import ProcessPoolExecutor
 
 from logic.config_loader import load_config
 from connectors.oracle_connector import get_oracle_connection
 from connectors.sqlserver_connector import get_sqlserver_connection
 from logic.partitioner import get_partitions
 from runners.reconcile import fetch_rows
-from logic.comparator import compare_rows, compare_row_pair
+from logic.comparator import compare_rows, compare_row_pair, compare_row_pairs
 from logic.reporter import DiscrepancyWriter
 from utils.logger import debug_log
 
@@ -136,11 +135,10 @@ def main():
                     dest_row = next(dest_iter, None)
 
             if row_pairs:
-                if use_parallel:
-                    with ProcessPoolExecutor(max_workers=4) as pool:
-                        results = list(pool.map(compare_row_pair, row_pairs))
-                else:
-                    results = [compare_row_pair(p) for p in row_pairs]
+                results = compare_row_pairs(
+                    row_pairs,
+                    parallel=use_parallel,
+                )
 
                 for pair, diffs in zip(row_pairs, results):
                     src_key = pair[0][primary_key]


### PR DESCRIPTION
## Summary
- visualize comparison progress with new `compare_row_pairs` helper
- display fix application progress in `fix_mismatches`
- use new helper in reconciliation runner
- add tqdm to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d09bb22e4832ca948a3fa366ecd1f