### PR TITLE
Parallel row comparison by primary key

### DIFF
--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -142,8 +142,9 @@ def main():
                     parallel=use_parallel,
                 )
 
-                for pair, diffs in zip(row_pairs, results):
-                    src_key = pair[0][primary_key]
+                for result in results:
+                    src_key = result["primary_key"]
+                    diffs = result["mismatches"]
                     if not diffs:
                         continue
                     for diff in diffs:

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -65,16 +65,20 @@ def test_compare_row_pairs_dataframe():
         (src2, dest2, columns, config),
     ]
     results = compare_row_pairs(pairs)
-    assert results[0] is None
     expected_src_hash = compute_row_hash(src2)
     expected_dest_hash = compute_row_hash(dest2)
-    assert results[1] == [
+    assert results == [
         {
-            "column": "col",
-            "source_value": "b",
-            "dest_value": "c",
-            "source_hash": expected_src_hash,
-            "dest_hash": expected_dest_hash,
+            "primary_key": 2,
+            "mismatches": [
+                {
+                    "column": "col",
+                    "source_value": "b",
+                    "dest_value": "c",
+                    "source_hash": expected_src_hash,
+                    "dest_hash": expected_dest_hash,
+                }
+            ],
         }
     ]
 
@@ -85,7 +89,7 @@ def test_compare_row_pairs_only_columns():
     columns = {"id": "id", "col": "col", "extra": "extra"}
     config = {"primary_key": "id", "comparison": {"only_columns": ["col"]}}
     results = compare_row_pairs([(src, dest, columns, config)])
-    assert results[0] is None
+    assert results == []
 
 
 def test_compare_row_pairs_normalize_types():
@@ -94,4 +98,4 @@ def test_compare_row_pairs_normalize_types():
     columns = {"id": "id", "amount": "amount"}
     config = {"primary_key": "id", "comparison": {"normalize_types": True}}
     results = compare_row_pairs([(src, dest, columns, config)])
-    assert results[0] is None
+    assert results == []


### PR DESCRIPTION
## Summary
- compare mismatched rows concurrently based on primary key
- update reconcile runner to consume new result format
- adjust tests for pk-based compare_row_pairs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507873f7fc832ca3bcf12d659b8925