### PR TITLE
Fix row hash ordering and add debug logs

### DIFF
--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -151,6 +151,11 @@ def main():
                     if not diffs:
                         continue
                     for diff in diffs:
+                        debug_log(
+                            f"Writing mismatch for PK {src_key}, column {diff['column']}",
+                            config,
+                            level="high",
+                        )
                         writer.write({
                             "primary_key": src_key,
                             "type": "mismatch",


### PR DESCRIPTION
## Summary
- handle row hash deterministically by sorting keys
- provide debug logging for row comparisons and diff writing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685095134c84832ca7b79ebbecb657a3