### PR TITLE
Stream mismatch results

### DIFF
--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -1,7 +1,6 @@
 """Command line entry point for running table reconciliation."""
 
 import argparse
-from tqdm import tqdm  # Ensure tqdm is imported at the top
 
 from logic.config_loader import load_config
 from connectors.oracle_connector import get_oracle_connection
@@ -137,20 +136,13 @@ def main():
                     })
                     dest_row = next(dest_iter, None)
 
-            from tqdm import tqdm  # Ensure tqdm is imported at the top
-
             if row_pairs:
-                results = compare_row_pairs(
+                for result in compare_row_pairs(
                     row_pairs,
                     parallel=use_parallel,
-                )
-
-                for result in tqdm(results, total=len(results), desc="Row-level diffing"):
+                ):
                     src_key = result["primary_key"]
-                    diffs = result["mismatches"]
-                    if not diffs:
-                        continue
-                    for diff in diffs:
+                    for diff in result["mismatches"]:
                         debug_log(
                             f"Writing mismatch for PK {src_key}, column {diff['column']}",
                             config,

--- a/tests/test_comparator.py
+++ b/tests/test_comparator.py
@@ -64,7 +64,7 @@ def test_compare_row_pairs_dataframe():
         (src1, dest1, columns, config),
         (src2, dest2, columns, config),
     ]
-    results = compare_row_pairs(pairs)
+    results = list(compare_row_pairs(pairs))
     expected_src_hash = compute_row_hash(src2)
     expected_dest_hash = compute_row_hash(dest2)
     assert results == [
@@ -88,7 +88,7 @@ def test_compare_row_pairs_only_columns():
     dest = {"id": 1, "col": "a", "extra": "y"}
     columns = {"id": "id", "col": "col", "extra": "extra"}
     config = {"primary_key": "id", "comparison": {"only_columns": ["col"]}}
-    results = compare_row_pairs([(src, dest, columns, config)])
+    results = list(compare_row_pairs([(src, dest, columns, config)]))
     assert results == []
 
 
@@ -97,5 +97,5 @@ def test_compare_row_pairs_normalize_types():
     dest = {"id": 1, "amount": "10"}
     columns = {"id": "id", "amount": "amount"}
     config = {"primary_key": "id", "comparison": {"normalize_types": True}}
-    results = compare_row_pairs([(src, dest, columns, config)])
+    results = list(compare_row_pairs([(src, dest, columns, config)]))
     assert results == []


### PR DESCRIPTION
## Summary
- yield diff results from `compare_row_pairs`
- stream mismatches as they are generated in `reconcile_runner`
- adapt comparator tests for generator output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509e16bb90832c84a9f2fc582901ab