### PR TITLE
Update progress bar during mismatch processing

### DIFF
--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -163,11 +163,11 @@ def main():
                 for result in compare_row_pairs(
                     generate_pairs(),
                     parallel=use_parallel,
+                    progress=pbar,
                 ):
                     src_key = result["primary_key"]
                     part = result.get("partition", {})
                     if result["mismatches"]:
-                        pbar.update(1)
                         if src_key not in seen_pks and len(sample) < 2:
                             sample.append((src_key, result["mismatches"][0]))
                             seen_pks.add(src_key)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,20 @@
+from logic.comparator import compare_row_pairs
+
+class DummyProgress:
+    def __init__(self):
+        self.n = 0
+        self.total = None
+        self.refresh_calls = 0
+    def refresh(self):
+        self.refresh_calls += 1
+
+def test_compare_row_pairs_updates_progress():
+    src = {"id": 1, "col": "a"}
+    dest = {"id": 1, "col": "b"}
+    columns = {"id": "id", "col": "col"}
+    config = {"primary_key": "id"}
+    progress = DummyProgress()
+    list(compare_row_pairs([(src, dest, columns, config)], progress=progress))
+    assert progress.total == 1
+    assert progress.n == 1
+    assert progress.refresh_calls >= 1


### PR DESCRIPTION
## Summary
- update `compare_row_pairs` to track progress of mismatch processing
- propagate progress tracking up to the reconciliation runner
- add regression test for progress updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850cfb03430832cb75d4b5487bf7236