### PR TITLE
Improve progress updates during comparison

### DIFF
--- a/logic/reporter.py
+++ b/logic/reporter.py
@@ -54,8 +54,8 @@ class DiscrepancyWriter:
             f"INSERT INTO {full_table} ({', '.join('[' + c + ']' for c in self.columns)}) "
             f"VALUES ({placeholders})"
         )
-        values = [[rec.get(c) for c in self.columns] for rec in self.buffer]
-        cursor.executemany(insert_sql, values)
+        for rec in self.buffer:
+            cursor.execute(insert_sql, [rec.get(c) for c in self.columns])
         self.conn.commit()
         self.buffer.clear()
 


### PR DESCRIPTION
## Summary
- refactor comparison to yield results as threads complete
- insert discrepancy rows one at a time to improve reliability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685174f6b9e8832c81808a5fab5b9637