### PR TITLE
Add row limit via SQL clauses

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Passing the `--debug` flag or setting a debug level in the YAML
 configuration enables logging output. Supported levels are `low`,
 `medium` and `high`, where `high` produces the most verbose output.
 
+To limit the number of rows fetched during testing, pass the `--limit`
+option to `reconcile_runner.py`:
+
+```bash
+python scripts/reconcile_runner.py --limit 50000
+```
+This restricts the amount of data retrieved from each table by applying a
+`FETCH FIRST`/`OFFSET` clause in the SQL queries, which speeds up test runs.
+
 This repository is intentionally minimal and focuses only on the core
 logic for comparing tables. Many features are missing, including retry
 logic, logging and tests.

--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -25,11 +25,18 @@ def main():
         choices=["low", "medium", "high"],
         help="set debug level",
     )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="maximum number of rows to fetch per table",
+    )
     args = parser.parse_args()
 
     config = load_config()
     if args.debug:
         config["debug"] = args.debug
+    if args.limit:
+        config["limit"] = args.limit
 
     debug_log("Starting reconciliation run", config, level="low")
 
@@ -78,6 +85,7 @@ def main():
                             dialect=src_dialect,
                             week_column=week_column,
                             config=config,
+                            limit=config.get("limit"),
                         )
                     )
 
@@ -94,6 +102,7 @@ def main():
                             dialect=dest_dialect,
                             week_column=week_column,
                             config=config,
+                            limit=config.get("limit"),
                         )
                     )
 

--- a/tests/test_fetch_rows.py
+++ b/tests/test_fetch_rows.py
@@ -4,19 +4,26 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from runners.reconcile import fetch_rows
 
 class DummyCursor:
-    def __init__(self):
+    def __init__(self, rows=None):
         self.executed = None
         self.arraysize = None
+        self.rows = rows or []
+        self.index = 0
     def execute(self, query, params):
         self.executed = params
     def fetchmany(self, size):
         if self.arraysize is None:
             self.arraysize = size
-        return []
+        if self.index >= len(self.rows):
+            return []
+        start = self.index
+        end = min(start + size, len(self.rows))
+        self.index = end
+        return self.rows[start:end]
 
 class DummyConn:
-    def __init__(self):
-        self.cursor_obj = DummyCursor()
+    def __init__(self, rows=None):
+        self.cursor_obj = DummyCursor(rows)
     def cursor(self):
         return self.cursor_obj
 
@@ -68,3 +75,27 @@ def test_fetch_rows_filters_week_oracle():
         )
     )
     assert conn.cursor_obj.executed == ("2021", "1", "3")
+
+
+def test_fetch_rows_limit():
+    """Verify limit parameter is passed to the query."""
+    rows = [(1,), (2,)]
+    conn = DummyConn(rows)
+    columns = {"id": "id", "year": "yr", "month": "mon"}
+    partition = {"year": 2021, "month": 1}
+    result = list(
+        fetch_rows(
+            conn,
+            "dbo",
+            "t",
+            columns,
+            partition,
+            "id",
+            "yr",
+            "mon",
+            batch_size=2,
+            limit=2,
+        )
+    )
+    assert len(result) == 2
+    assert conn.cursor_obj.executed == ("2021", "1", 2)


### PR DESCRIPTION
## Summary
- limit rows directly in SQL queries
- remove Python-side limit loops
- document the SQL-level behavior
- update tests for new limit implementation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68517d54f334832c99b9b2335c9285c4