### PR TITLE
Add single record option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ connectivity issues:
 python scripts/reconcile_runner.py --output-mismatches
 ```
 
+When debugging specific issues you can process a single row by supplying its
+primary key value using the `--record` option:
+
+```bash
+python scripts/reconcile_runner.py --record 12345
+```
+
 This repository is intentionally minimal and focuses only on the core
 logic for comparing tables. Many features are missing, including retry
 logic, logging and tests.

--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -35,6 +35,10 @@ def main():
         action="store_true",
         help="print discrepancy records to stdout",
     )
+    parser.add_argument(
+        "--record",
+        help="process only the record with this primary key value",
+    )
     args = parser.parse_args()
 
     config = load_config()
@@ -44,6 +48,8 @@ def main():
         config["limit"] = args.limit
     if args.output_mismatches:
         config["output_mismatches"] = True
+    if args.record:
+        config["record_pk"] = args.record
 
     debug_log("Starting reconciliation run", config, level="low")
 
@@ -98,6 +104,7 @@ def main():
                             week_column=week_column,
                             config=config,
                             limit=config.get("limit"),
+                            pk_value=config.get("record_pk"),
                         )
                     )
 
@@ -115,6 +122,7 @@ def main():
                             week_column=week_column,
                             config=config,
                             limit=config.get("limit"),
+                            pk_value=config.get("record_pk"),
                         )
                     )
 

--- a/tests/test_fetch_rows.py
+++ b/tests/test_fetch_rows.py
@@ -99,3 +99,44 @@ def test_fetch_rows_limit():
     )
     assert len(result) == 2
     assert conn.cursor_obj.executed == ("2021", "1", 2)
+
+
+def test_fetch_rows_pk_value():
+    conn = DummyConn()
+    columns = {"id": "id", "year": "yr", "month": "mon"}
+    partition = {"year": 2021, "month": 1}
+    list(
+        fetch_rows(
+            conn,
+            "dbo",
+            "t",
+            columns,
+            partition,
+            "id",
+            "yr",
+            "mon",
+            pk_value="42",
+        )
+    )
+    assert conn.cursor_obj.executed == ("2021", "1", "42")
+
+
+def test_fetch_rows_pk_value_oracle():
+    conn = DummyConn()
+    columns = {"id": "id", "year": "yr", "month": "mon"}
+    partition = {"year": 2021, "month": 1}
+    list(
+        fetch_rows(
+            conn,
+            "dbo",
+            "t",
+            columns,
+            partition,
+            "id",
+            "yr",
+            "mon",
+            dialect="oracle",
+            pk_value="99",
+        )
+    )
+    assert conn.cursor_obj.executed == ("2021", "1", "99")


### PR DESCRIPTION
## Summary
- allow running reconciliation for a single primary key
- support pk filter in `fetch_rows`
- expose `--record` CLI option
- document the new option
- test pk filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518a178214832c8f23dbc411b52c38