### PR TITLE
Improve tqdm progress bar descriptions

### DIFF
--- a/logic/comparator.py
+++ b/logic/comparator.py
@@ -106,7 +106,7 @@ def _filter_pairs_by_hash(
     # Materialize chunks for tqdm progress bar
     chunks = list(_chunked(row_pairs, chunk_size))
     for i, chunk in enumerate(
-        tqdm(chunks, desc="Filtering hash mismatches", unit="chunk")
+        tqdm(chunks, desc="Filtering mismatched row hashes", unit="chunk")
     ):
         for pair in process(chunk, i):
             yield pair

--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -94,7 +94,7 @@ def main():
                 sample: list[tuple[Any, dict]] = []
                 seen_pks = set()
                 workers = config.get("comparison", {}).get("workers", 4)
-                with tqdm(desc="mismatched rows", unit="row") as pbar:
+                with tqdm(desc="mismatches found", unit="row") as pbar:
                     for partition in get_partitions(config):
                         debug_log(
                             f"Partition: {partition}",
@@ -154,7 +154,7 @@ def main():
                         total_rows = max(len(src_rows), len(dest_rows))
 
                         def row_pairs():
-                            with tqdm(total=total_rows, desc="processing rows", unit="row") as progress:
+                            with tqdm(total=total_rows, desc="processing row pairs", unit="row") as progress:
                                 nonlocal src_row, dest_row
                                 while src_row is not None or dest_row is not None:
                                     if src_row is not None:


### PR DESCRIPTION
## Summary
- rename progress bar in `reconcile_runner` to `mismatches found`
- use `processing row pairs` desc when comparing rows
- clarify progress message for hash filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853372864fc832ca8f302902eda9d31