### PR TITLE
Improve tqdm partition output

### DIFF
--- a/scripts/fix_mismatches.py
+++ b/scripts/fix_mismatches.py
@@ -12,6 +12,7 @@ from logic.partitioner import get_partitions
 from logic.config_loader import load_config
 from connectors.sqlserver_connector import get_sqlserver_connection
 from utils.logger import debug_log
+from utils import format_partition
 from tqdm import tqdm
 
 
@@ -53,6 +54,7 @@ def fix_mismatches(config: Dict, *, dry_run: Optional[bool] = None) -> None:
         partitions = list(get_partitions(config)) or [{}]
         with tqdm(total=len(partitions), desc="partitions", unit="part") as part_bar:
             for partition in partitions:
+                part_bar.set_postfix_str(format_partition(partition))
                 part_bar.update(1)
                 part_params = []
                 where_clauses = ["[type] = 'mismatch'"]
@@ -76,6 +78,7 @@ def fix_mismatches(config: Dict, *, dry_run: Optional[bool] = None) -> None:
                 columns_to_update = [row[0] for row in cur.fetchall()]
 
                 with tqdm(columns_to_update, desc="columns", unit="col", leave=False) as col_bar:
+                    col_bar.set_postfix_str(format_partition(partition))
                     for col in columns_to_update:
                         dest_column = dest_cols.get(col, col)
 

--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -17,6 +17,7 @@ from runners.reconcile import fetch_rows
 from logic.comparator import compare_row_pairs
 from logic.reporter import DiscrepancyWriter
 from utils.logger import debug_log
+from utils import format_partition
 from tqdm import tqdm
 
 from scripts.fix_mismatches import main as fix_mismatches_main
@@ -110,6 +111,7 @@ def main():
                 partitions = list(get_partitions(config))
                 with tqdm(total=len(partitions), desc="partitions", unit="part") as partbar, tqdm(desc="mismatches found", unit="row") as pbar:
                     for partition in partitions:
+                        partbar.set_postfix_str(format_partition(partition))
                         partbar.update(1)
                         debug_log(
                             f"Partition: {partition}",
@@ -176,6 +178,8 @@ def main():
                                 else nullcontext()
                             )
                             with bar_ctx as progress:
+                                if use_bar:
+                                    progress.set_postfix_str(format_partition(partition))
                                 nonlocal src_row, dest_row
                                 while src_row is not None or dest_row is not None:
                                     if src_row is not None:

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+
+def format_partition(partition: dict) -> str:
+    """Return a short string describing *partition* for progress bars."""
+    if not partition:
+        return "all"
+
+    parts = []
+    year = partition.get("year")
+    month = partition.get("month")
+    week = partition.get("week")
+
+    if year is not None:
+        parts.append(str(year))
+    if month is not None:
+        parts.append(str(month))
+    if week is not None:
+        parts.append(f"W{week}")
+
+    return "-".join(parts)
+


### PR DESCRIPTION
## Summary
- add utility to format partition info
- display current partition in fix_mismatches progress bars
- show current partition when reconciling rows

## Testing
- `pip install xxhash`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853717ceb00832ca1ffd484ce688de8