### PR TITLE
Improve progress output and log to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/__pycache__/
+debug.log

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ written to a table on the destination SQL Server.
    file.
 
 Passing the `--debug` flag or setting a debug level in the YAML
-configuration enables logging output. Supported levels are `low`,
-`medium` and `high`, where `high` produces the most verbose output.
+configuration enables logging output written to `debug.log` in the project
+root. Supported levels are `low`, `medium` and `high`, where `high` produces
+the most verbose output.
 
 To limit the number of rows fetched during testing, pass the `--limit`
 option to `reconcile_runner.py`:

--- a/scripts/fix_mismatches.py
+++ b/scripts/fix_mismatches.py
@@ -77,7 +77,12 @@ def fix_mismatches(config: Dict, *, dry_run: Optional[bool] = None) -> None:
                 )
                 columns_to_update = [row[0] for row in cur.fetchall()]
 
-                with tqdm(columns_to_update, desc="columns", unit="col", leave=False) as col_bar:
+                with tqdm(
+                    columns_to_update,
+                    desc=f"{format_partition(partition)} columns",
+                    unit="col",
+                    leave=False,
+                ) as col_bar:
                     col_bar.set_postfix_str(format_partition(partition))
                     for col in columns_to_update:
                         dest_column = dest_cols.get(col, col)

--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -61,6 +61,7 @@ def process_partition(
     """Process a single partition using its own database connections."""
 
     start_event.wait()
+    pbar.set_description(f"mismatches {format_partition(partition)}")
     with get_oracle_connection(src_env, config) as src_conn, get_sqlserver_connection(dest_env, config) as dest_conn:
         dest_conn.cursor().fast_executemany = True
         with ThreadPoolExecutor(max_workers=2) as executor:
@@ -128,7 +129,11 @@ def process_partition(
             def row_pairs():
                 use_bar = total_rows <= 1000
                 bar_ctx = (
-                    tqdm(total=total_rows, desc="processing row pairs", unit="row")
+                    tqdm(
+                        total=total_rows,
+                        desc=f"rows {format_partition(partition)}",
+                        unit="row",
+                    )
                     if use_bar
                     else nullcontext()
                 )

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 
 def _get_config_level(config: dict | None) -> str:
     """Return the configured debug level from *config*."""
@@ -18,9 +20,13 @@ def _get_config_level(config: dict | None) -> str:
     return "low"
 
 
+LOG_FILE = os.getenv("DEBUG_LOG_FILE", "debug.log")
+
+
 def debug_log(message: str, config: dict | None = None, *, level: str = "high") -> None:
-    """Print debug *message* when the configured level is >= ``level``."""
+    """Write debug *message* to ``LOG_FILE`` when enabled."""
     current = _get_config_level(config)
     ranks = {"low": 1, "medium": 2, "high": 3}
     if ranks.get(current, 1) >= ranks.get(level, 3):
-        print("[DEBUG]", message)
+        with open(LOG_FILE, "a", encoding="utf-8") as f:
+            f.write(f"{message}\n")


### PR DESCRIPTION
## Summary
- redirect debug logging to `debug.log`
- mention file logging in README
- add `debug.log` to `.gitignore`
- display partition info in progress bar descriptions

## Testing
- `pip install xxhash`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853842a9630832cadfa6cad12f3316c