### PR TITLE
Implement auto worker count

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -35,7 +35,7 @@ comparison:
   parallel: true
   parallel_mode: batch
   include_nulls: true
-  workers: 4
+  workers: auto
 
 partitioning:
   year_column: year

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 python-dateutil
 tqdm
 pandas
+psutil

--- a/scripts/reconcile_runner.py
+++ b/scripts/reconcile_runner.py
@@ -18,6 +18,8 @@ from logic.comparator import compare_row_pairs
 from logic.reporter import DiscrepancyWriter
 from utils.logger import debug_log
 from utils import format_partition
+from utils.system_resources import get_optimal_worker_count
+import psutil
 from tqdm import tqdm
 from collections import defaultdict
 import threading
@@ -286,6 +288,14 @@ def main():
 
     debug_log("Starting reconciliation run", config, level="low")
 
+    comparison_cfg = config.get("comparison", {})
+    workers = comparison_cfg.get("workers")
+    if not workers or workers == "auto":
+        workers = get_optimal_worker_count()
+        debug_log(f"CPU cores: {os.cpu_count()}, Available RAM: {psutil.virtual_memory().available / (1024**3):.2f} GB", config)
+        debug_log(f"Auto-detected optimal worker count: {workers}", config)
+    comparison_cfg["workers"] = workers
+
     src_env = config["source"]["resolved_env"]
     dest_env = config["destination"]["resolved_env"]
     src_schema = config["source"].get("schema", "")
@@ -310,7 +320,7 @@ def main():
     try:
         sample: list[tuple[Any, dict]] = []
         seen_pks: set[Any] = set()
-        workers = config.get("comparison", {}).get("workers", 4)
+        workers = comparison_cfg.get("workers", 4)
         partitions = list(get_partitions(config))
 
         groups: dict[tuple[str, str], list[dict]] = defaultdict(list)

--- a/utils/system_resources.py
+++ b/utils/system_resources.py
@@ -1,0 +1,13 @@
+import os
+import psutil
+
+
+def get_optimal_worker_count(min_mem_per_worker_gb: float = 1.5, cpu_util_fraction: float = 0.75) -> int:
+    """Return a recommended number of workers based on system CPU and memory limits."""
+    total_cores = os.cpu_count() or 1
+    available_mem_gb = psutil.virtual_memory().available / (1024 ** 3)
+
+    max_by_cpu = max(1, int(total_cores * cpu_util_fraction))
+    max_by_mem = max(1, int(available_mem_gb / min_mem_per_worker_gb))
+
+    return min(max_by_cpu, max_by_mem)


### PR DESCRIPTION
## Summary
- set comparison workers to `auto` by default
- determine worker count automatically based on available CPU cores and RAM
- expose helper for system resource checks
- require `psutil` to inspect memory

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538942f440832c9d78e1d2991d94be