### PR TITLE
Add pqdm progress for partition processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This script updates only the differing columns and accepts a `--no-dry-run`
 flag when you want to preview the SQL statements.
 
 This repository remains intentionally small but now includes simple
-logging via `utils.logger`, tqdm progress bars and a suite of unit tests.
+logging via `utils.logger`, progress bars driven by `pqdm` and a suite of unit tests.
 Retry logic and advanced error handling are still out of scope to keep
 the example focused on reconciliation.
 


### PR DESCRIPTION
## Summary
- use `pqdm` threads when processing partitions in `reconcile_runner`
- drop unused imports and old loop logic
- update README to mention pqdm progress bars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685398358d20832c92f5545bafa992aa